### PR TITLE
Add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 [Babel](https://babeljs.io/) plugin that transforms ES2015 System.import into CommonJS require.
 
+## Deprecation notice
+
+** Since [import() proposal](https://github.com/tc39/proposal-dynamic-import) was accepted, `System.import` function now is obsolete and this plugin is not recommended to use in new projects. Please use  `import()` function with [babel-plugin-transform-import-commonjs](https://www.npmjs.com/package/babel-plugin-transform-import-commonjs) instead. **
+
+
 ## How this works
 
 This plugin transforms

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-transform-system-import-commonjs",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Transform ES2015 System.import to CommonJS require",
   "main": "lib/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,19 @@ let buildPromise = template(`
   }.bind(this));
 `);
 
+let deprecationReported = false;
+
 export default function () {
+  if (!deprecationReported) {
+    console.warn(
+`babel-plugin-transform-system-import-commonjs: Using System.import is deprecated.
+Since import() proposal was accepted, System.import function now is obsolete and this plugin is not recommended to use in new projects.
+Please use import() function with https://www.npmjs.com/package/babel-plugin-transform-import-commonjs instead.`
+    );
+
+    deprecationReported = true;
+  }
+
   return {
     visitor: {
       CallExpression: function (path) {


### PR DESCRIPTION
Since [import() proposal](https://github.com/tc39/proposal-dynamic-import) was accepted, `System.import` function now is obsolete and this plugin is not recommended to use in new projects.